### PR TITLE
Separate official content from YARN content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# tauri generated stuff
+/src-tauri/gen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yet_another_launcher",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yet_another_launcher",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/src/profiles/types.ts
+++ b/src/profiles/types.ts
@@ -57,6 +57,7 @@ export interface VersionInfoEmbedded {
 export interface Metadata {
     name: string,
     description: string,
+    badge?: string,
 
     iconUrl: string,
     bannerBackUrl: string,

--- a/src/routes/AppProfile/AppProfile.module.css
+++ b/src/routes/AppProfile/AppProfile.module.css
@@ -46,10 +46,10 @@
     overflow: hidden;
 }
 
-.verifiedTag {
+.profileBadge {
     display: flex;
     height: 31px;
-    padding: 12px 5px 12px 10px;
+    padding: 12px 10px;
     justify-content: center;
     align-items: center;
     gap: 5px;
@@ -61,6 +61,10 @@
     color: #BDBDBD;
     font-size: 15px;
     font-weight: 700;
+}
+
+.profileBadge > svg {
+    margin-right: -5px;
 }
 
 .bannerOptions {

--- a/src/routes/AppProfile/index.tsx
+++ b/src/routes/AppProfile/index.tsx
@@ -52,7 +52,7 @@ function AppProfile() {
                 <ProfileIcon className={styles.bannerAppIcon} iconUrl={metadata.iconUrl} />
                 <div>
                     {profile.metadata.badge &&
-                        <div className={styles.verifiedTag}>
+                        <div className={styles.profileBadge}>
                             {profile.metadata.badge} {profile.metadata.badge === "Official" && <VerifiedIcon />}
                         </div>
                     }

--- a/src/routes/AppProfile/index.tsx
+++ b/src/routes/AppProfile/index.tsx
@@ -51,9 +51,11 @@ function AppProfile() {
             <div className={styles.bannerApp}>
                 <ProfileIcon className={styles.bannerAppIcon} iconUrl={metadata.iconUrl} />
                 <div>
-                    <div className={styles.verifiedTag}>
-                        Official <VerifiedIcon />
-                    </div>
+                    {profile.metadata.badge &&
+                        <div className={styles.verifiedTag}>
+                            {profile.metadata.badge} {profile.metadata.badge === "Official" && <VerifiedIcon />}
+                        </div>
+                    }
                     {activeProfile.displayName !== undefined ? activeProfile.displayName : metadata.name}
                 </div>
             </div>

--- a/src/routes/Marketplace/Marketplace.module.css
+++ b/src/routes/Marketplace/Marketplace.module.css
@@ -107,7 +107,6 @@
 
 .section > .title > .left {
     display: flex;
-    width: 179px;
     justify-content: space-between;
     align-items: center;
 

--- a/src/routes/Marketplace/MarketplacePopup.module.css
+++ b/src/routes/Marketplace/MarketplacePopup.module.css
@@ -96,10 +96,10 @@
     text-transform: uppercase;
 }
 
-.verifiedTag {
+.profileBadge {
     display: flex;
     height: 31px;
-    padding: 12px 5px 12px 10px;
+    padding: 12px 10px;
     justify-content: center;
     align-items: center;
     gap: 5px;
@@ -111,6 +111,10 @@
     color: #BDBDBD;
     font-size: 15px;
     font-weight: 700;
+}
+
+.profileBadge > svg {
+    margin-right: -5px;
 }
 
 .bannerOptions {

--- a/src/routes/Marketplace/MarketplacePopup.tsx
+++ b/src/routes/Marketplace/MarketplacePopup.tsx
@@ -90,9 +90,11 @@ const MarketplacePopup: React.FC<Props> = ({ marketplaceProfile, setSelectedProf
                 <div className={styles.bannerApp}>
                     <ProfileIcon className={styles.bannerAppIcon} iconUrl={metadata.iconUrl} />
                     <div>
-                        <div className={styles.verifiedTag}>
-                            Official <VerifiedIcon />
-                        </div>
+                        {profile.metadata.badge &&
+                            <div className={styles.verifiedTag}>
+                                {profile.metadata.badge} {profile.metadata.badge === "Official" && <VerifiedIcon />}
+                            </div>
+                        }
                         {metadata.name}
                     </div>
                 </div>

--- a/src/routes/Marketplace/MarketplacePopup.tsx
+++ b/src/routes/Marketplace/MarketplacePopup.tsx
@@ -91,7 +91,7 @@ const MarketplacePopup: React.FC<Props> = ({ marketplaceProfile, setSelectedProf
                     <ProfileIcon className={styles.bannerAppIcon} iconUrl={metadata.iconUrl} />
                     <div>
                         {profile.metadata.badge &&
-                            <div className={styles.verifiedTag}>
+                            <div className={styles.profileBadge}>
                                 {profile.metadata.badge} {profile.metadata.badge === "Official" && <VerifiedIcon />}
                             </div>
                         }

--- a/src/routes/Marketplace/index.tsx
+++ b/src/routes/Marketplace/index.tsx
@@ -90,11 +90,18 @@ function Marketplace() {
                     marketIndex.profiles.filter(i => i.type === "application").map(i =>
                         <MarketplaceProfileView profile={i} setSelectedProfile={setSelectedProfile} key={i.uuid} />
                     )
+                } 
+            </MarketplaceSection>
+            <MarketplaceSection name="Official Setlists">
+                {
+                    marketIndex.profiles.filter(i => i.type === "setlist" && i.category === "official_setlist").map(i =>
+                        <MarketplaceProfileView profile={i} setSelectedProfile={setSelectedProfile} key={i.uuid} />
+                    )
                 }
             </MarketplaceSection>
-            <MarketplaceSection name="All Setlists">
+            <MarketplaceSection name="Yet Another Rhythm Network Setlists">
                 {
-                    marketIndex.profiles.filter(i => i.type === "setlist").map(i =>
+                    marketIndex.profiles.filter(i => i.type === "setlist" && i.category === "yarn_setlist").map(i =>
                         <MarketplaceProfileView profile={i} setSelectedProfile={setSelectedProfile} key={i.uuid} />
                     )
                 }


### PR DESCRIPTION
* Added separate section for YARN setlist
    * For setlists to appear in the official content section, the setlist must have a category of `"official_setlist"` in the profile index on releases.yarg.in. Currently all setlists have the "official_setlist" category.
    * For setlists to appear in the YARN section, the setlist must have a category of `"yarn_setlist"` in the profile index on releases.yarg.in.
* Add support for per-profile badge customization ("Official" with a checkmark)
    * By default, there is no badge displayed
    * Setting `badge` in profile metadata on releases.yarg.in to any text will display the badge
    * Setting `badge` to the string "Official" will display the verification badge